### PR TITLE
refactor private / local match and pre-parse with heuristic

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -27,18 +27,25 @@
       };
     },
     urlSync: function(url, opts) {
-      var privateAndLocalNetworks, regexStr;
+      var commonPrefix, commonSuffix, excludePrivateAndLocalNetworks, prelimREstr, regexStr;
       if (opts == null) {
         opts = {};
       }
-      privateAndLocalNetworks = function() {
-        if (opts.allowPrivateNetworks) {
-          return '';
-        }
-        return "(?!10(?:\\.\\d{1,3}){3})" + "(?!127(?:\\.\\d{1,3}){3})" + "(?!169\\.254(?:\\.\\d{1,3}){2})" + "(?!192\\.168(?:\\.\\d{1,3}){2})" + "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})";
-      };
-      regexStr = "^" + "(?:(?:https?|ftp)://)" + "(?:\\S+(?::\\S*)?@)?" + "(?:" + privateAndLocalNetworks() + "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" + "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" + "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" + "|" + "(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)" + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*" + "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" + ")" + "(?::\\d{2,5})?" + "(?:/[^\\s]*)?" + "$";
-      return match(new RegExp(regexStr, "i"), url);
+      excludePrivateAndLocalNetworks = "10(?:\\.\\d{1,3}){3}" + "|127(?:\\.\\d{1,3}){3}" + "|169\\.254(?:\\.\\d{1,3}){2}" + "|192\\.168(?:\\.\\d{1,3}){2}" + "|172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2}";
+      commonPrefix = "^" + "(?:(?:https?|ftp)://)" + "(?:\\S+(?::\\S*)?@)?";
+      commonSuffix = "(?::\\d{2,5})?" + "(?:/[^\\s]*)?" + "$";
+      prelimREstr = "(?:.*)\\." + "(?:" + "(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4])" + "|" + "(?:[a-z\\u00a1-\\uffff]{2,10})" + ")";
+      regexStr = "(?:" + "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" + "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" + "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" + "|" + "(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)" + "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*" + "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" + ")";
+      if (!match(new RegExp(commonPrefix + prelimREstr + commonSuffix, "i"), url)) {
+        return false;
+      }
+      if (!match(new RegExp(commonPrefix + regexStr + commonSuffix, "i"), url)) {
+        return false;
+      }
+      if (opts.allowPrivateNetworks) {
+        return true;
+      }
+      return !match(new RegExp(commonPrefix + excludePrivateAndLocalNetworks + commonSuffix, "i"), url);
     },
     url: function(msg, opts) {
       if (msg == null) {

--- a/test/fixtures/patterns/urls.json
+++ b/test/fixtures/patterns/urls.json
@@ -50,6 +50,7 @@
     "http://##",
     "http://##/",
     "http://foo.bar?q=Spaces should be encoded",
+    "http://actuallyacommonerroristoforgetthetld",
     "//",
     "//a",
     "///a",

--- a/test/pattern_tests.coffee
+++ b/test/pattern_tests.coffee
@@ -33,18 +33,19 @@ shouldBehaveLikeAnAsyncValidator = (validatorFn, defaultErrorMessage, fixtures) 
 
 
 shouldBehaveLikeASyncValidator = (validatorFn, defaultErrorMessage, fixtures) ->
+
   describe 'valid', ->
     for validCase in fixtures.valid
       do (validCase) ->
         it "should allow #{validCase}", ->
-          validatorFn(validCase).should.be.true
-
+          validatorFn(validCase).should.not.be.false
 
   describe 'invalid', ->
     for invalidCase in fixtures.invalid
       do (invalidCase) ->
         it "should not allow #{invalidCase}", ->
           validatorFn(invalidCase).should.be.false
+
 
 describe '#urls',      -> shouldBehaveLikeAnAsyncValidator(validators.pattern.url,     "Invalid Url specified", fixtures.urls)
 describe '#urlSync',   -> shouldBehaveLikeASyncValidator(validators.pattern.urlSync,   "Invalid Url specified", fixtures.urls)
@@ -62,5 +63,5 @@ describe '#urlSync opts', ->
           validators.pattern.urlSync(validCase).should.be.false
 
 
-# describe '#emails',    -> shouldBehaveLikeAnAsyncValidator(validators.pattern.email,   "Invalid Email specified", fixtures.emails)
-# describe '#emailSync', -> shouldBehaveLikeASyncValidator(validators.pattern.emailSync, "Invalid Email specified", fixtures.emails)
+describe '#emails',    -> shouldBehaveLikeAnAsyncValidator(validators.pattern.email,   "Invalid Email specified", fixtures.emails)
+describe '#emailSync', -> shouldBehaveLikeASyncValidator(validators.pattern.emailSync, "Invalid Email specified", fixtures.emails)

--- a/test/pattern_tests.coffee
+++ b/test/pattern_tests.coffee
@@ -38,7 +38,7 @@ shouldBehaveLikeASyncValidator = (validatorFn, defaultErrorMessage, fixtures) ->
     for validCase in fixtures.valid
       do (validCase) ->
         it "should allow #{validCase}", ->
-          validatorFn(validCase).should.not.be.false
+          validatorFn(validCase).should.be.true
 
   describe 'invalid', ->
     for invalidCase in fixtures.invalid


### PR DESCRIPTION
 to avoid v8 hang on recapture

one common error is to forget the tld.
if the target website didn't get in on the first few generations of squatting, it may have a name like
www.reallylongwebsitename.com

if the field being validated is missing the TLD, then reallylongwebsitename may exceed a practical limit, and run into V8's amazing capacity to spend literally hours backtracking the tail of the pattern. https://code.google.com/p/v8/issues/detail?id=2254
