### PR TITLE
test common false-positive local url

### DIFF
--- a/src/pattern.coffee
+++ b/src/pattern.coffee
@@ -40,7 +40,7 @@ module.exports = v =
       "$"
 
     localStr =
-      "(?:\\\\)" +
+      "^(?:\\\\)" +
       # one or more paths
       "(?:\\\\[^\\s]*)+" +
       # optional filename extension

--- a/test/fixtures/patterns/urls.json
+++ b/test/fixtures/patterns/urls.json
@@ -87,6 +87,11 @@
     "\\\\full\\directory\\structure\\file.htm"
   ],
 
+  "localFilesInvalid": [
+    "http:\\\\somefile.txt",
+    "https:\\\\full\\directory\\structure\\file.htm"
+  ],
+
   "privateNetworks": [
     "http://10.103.222.50",
     "http://127.103.222.50",

--- a/test/pattern_tests.coffee
+++ b/test/pattern_tests.coffee
@@ -68,6 +68,11 @@ describe '#urlSync opts', ->
         it "should allow #{validCase}", ->
           validators.pattern.urlSync(validCase, allowLocalFiles: true).should.be.true
 
+    for invalidCase in fixtures.urls.localFilesInvalid
+      do (invalidCase) ->
+        it "should not allow #{invalidCase}", ->
+          validators.pattern.urlSync(invalidCase, allowLocalFiles: true).should.be.false
+
   describe 'allowLocalFiles is false', ->
     for validCase in fixtures.urls.localFiles
       do (validCase) ->


### PR DESCRIPTION
oops: without a caret, the localfiles regex allowed through the very likely error:
http:\\root\path\file.ext

fixed regex and added new tests to fixture
